### PR TITLE
Update python, setuptools and wheel version to latests

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This [Homebrew](http://brew.sh) tap provides formulæ to install multiple Python versions.
 
-We currently support Python 3.3.5, Python 3.4.3, and Python 3.5.0rc3 (requires --devel).
+We currently support Python 3.3.6, Python 3.4.3, and Python 3.5.0.
 
 ## How do I install these formulæ?
 

--- a/python33.rb
+++ b/python33.rb
@@ -1,10 +1,10 @@
 class Python33 < Formula
   desc "Interpreted, interactive, object-oriented programming language"
   homepage "https://www.python.org/"
-  url 'http://python.org/ftp/python/3.3.5/Python-3.3.5.tgz'
-  sha1 '15f24702c5ae07d364606c663e515c1d9ba58615'
+  url 'http://python.org/ftp/python/3.3.5/Python-3.3.6.tgz'
+  sha1 'a4d96b5cad5ed04cf02c9fcedaaaab3491bc885f'
   revision 2
-  
+
   head "https://hg.python.org/cpython", :using => :hg, :branch => '3.3'
 
   option :universal
@@ -27,8 +27,8 @@ class Python33 < Formula
   skip_clean "bin/easy_install3", "bin/easy_install-3.3"
 
   resource "setuptools" do
-    url "https://pypi.python.org/packages/source/s/setuptools/setuptools-18.3.1.tar.gz"
-    sha256 "2fa230727104b07e522deec17929e84e041c9047e392c055347a02b0d5ca874d"
+    url "https://pypi.python.org/packages/source/s/setuptools/setuptools-18.3.2.tar.gz"
+    sha256 "8c4ab0c4f227730519dc1e020f875b3ef97e643c8f43a98a4fa0c46fbad12450"
   end
 
   resource "pip" do
@@ -37,8 +37,8 @@ class Python33 < Formula
   end
 
   resource "wheel" do
-    url "https://pypi.python.org/packages/source/w/wheel/wheel-0.24.0.tar.gz"
-    sha256 "ef832abfedea7ed86b6eae7400128f88053a1da81a37c00613b1279544d585aa"
+    url "https://pypi.python.org/packages/source/w/wheel/wheel-0.26.0.tar.gz"
+    sha256 "eaad353805c180a47545a256e6508835b65a8e830ba1093ed8162f19a50a530c"
   end
 
   # Homebrew's tcl-tk is built in a standard unix fashion (due to link errors)

--- a/python33.rb
+++ b/python33.rb
@@ -1,7 +1,7 @@
 class Python33 < Formula
   desc "Interpreted, interactive, object-oriented programming language"
   homepage "https://www.python.org/"
-  url 'http://python.org/ftp/python/3.3.5/Python-3.3.6.tgz'
+  url 'http://python.org/ftp/python/3.3.6/Python-3.3.6.tgz'
   sha1 'a4d96b5cad5ed04cf02c9fcedaaaab3491bc885f'
   revision 2
 

--- a/python34.rb
+++ b/python34.rb
@@ -25,8 +25,8 @@ class Python34 < Formula
   skip_clean "bin/easy_install3", "bin/easy_install-3.4"
 
   resource "setuptools" do
-    url "https://pypi.python.org/packages/source/s/setuptools/setuptools-18.3.1.tar.gz"
-    sha256 "2fa230727104b07e522deec17929e84e041c9047e392c055347a02b0d5ca874d"
+    url "https://pypi.python.org/packages/source/s/setuptools/setuptools-18.3.2.tar.gz"
+    sha256 "8c4ab0c4f227730519dc1e020f875b3ef97e643c8f43a98a4fa0c46fbad12450"
   end
 
   resource "pip" do
@@ -35,8 +35,8 @@ class Python34 < Formula
   end
 
   resource "wheel" do
-    url "https://pypi.python.org/packages/source/w/wheel/wheel-0.24.0.tar.gz"
-    sha256 "ef832abfedea7ed86b6eae7400128f88053a1da81a37c00613b1279544d585aa"
+    url "https://pypi.python.org/packages/source/w/wheel/wheel-0.26.0.tar.gz"
+    sha256 "eaad353805c180a47545a256e6508835b65a8e830ba1093ed8162f19a50a530c"
   end
 
   # Homebrew's tcl-tk is built in a standard unix fashion (due to link errors)

--- a/python35.rb
+++ b/python35.rb
@@ -4,11 +4,6 @@ class Python35 < Formula
   url "https://www.python.org/ftp/python/3.5.0/Python-3.5.0.tar.xz"
   sha256 "d6d7aa1634a5eeeca6ed4fca266982a04f84bd8f3945a9179e20b24ad2e2be91"
 
-  devel do
-    url "https://www.python.org/ftp/python/3.5.0/Python-3.5.0rc4.tgz"
-    sha256 "d2576bcff852a8818842da2496782576413bd32ce3dd835192f86eeec4384379"
-  end
-
   head "https://hg.python.org/cpython", :using => :hg
 
   option :universal
@@ -31,8 +26,8 @@ class Python35 < Formula
   skip_clean "bin/easy_install3", "bin/easy_install-3.5", "bin/easy_install-3.6"
 
   resource "setuptools" do
-    url "https://pypi.python.org/packages/source/s/setuptools/setuptools-18.3.1.tar.gz"
-    sha256 "2fa230727104b07e522deec17929e84e041c9047e392c055347a02b0d5ca874d"
+    url "https://pypi.python.org/packages/source/s/setuptools/setuptools-18.3.2.tar.gz"
+    sha256 "8c4ab0c4f227730519dc1e020f875b3ef97e643c8f43a98a4fa0c46fbad12450"
   end
 
   resource "pip" do
@@ -41,8 +36,8 @@ class Python35 < Formula
   end
 
   resource "wheel" do
-    url "https://pypi.python.org/packages/source/w/wheel/wheel-0.24.0.tar.gz"
-    sha256 "ef832abfedea7ed86b6eae7400128f88053a1da81a37c00613b1279544d585aa"
+    url "https://pypi.python.org/packages/source/w/wheel/wheel-0.26.0.tar.gz"
+    sha256 "eaad353805c180a47545a256e6508835b65a8e830ba1093ed8162f19a50a530c"
   end
 
   # Homebrew's tcl-tk is built in a standard unix fashion (due to link errors)


### PR DESCRIPTION
- Update py33 version(3.3.5->3.3.6)
- Remove py35 devel because rc4 is old.
- Update setuptools version(18.3.1->18.3.2) for py33, py34 and py35
- Update wheel version(0.24.0->0.26.0) for py33, py34 and py35
