### PR TITLE
Change Python33/34 install command to 'make altinstall'

### DIFF
--- a/python33.rb
+++ b/python33.rb
@@ -4,7 +4,7 @@ class Python33 < Formula
   url 'http://python.org/ftp/python/3.3.5/Python-3.3.5.tgz'
   sha1 '15f24702c5ae07d364606c663e515c1d9ba58615'
   revision 2
-  
+
   head "https://hg.python.org/cpython", :using => :hg, :branch => '3.3'
 
   option :universal
@@ -146,7 +146,7 @@ class Python33 < Formula
 
     ENV.deparallelize # Installs must be serialized
     # Tell Python not to install into /Applications (default for framework builds)
-    system "make", "install", "PYTHONAPPSDIR=#{prefix}"
+    system "make", "altinstall", "PYTHONAPPSDIR=#{prefix}"
     # Demos and Tools
     system "make", "frameworkinstallextras", "PYTHONAPPSDIR=#{share}/python3"
     system "make", "quicktest" if build.include? "quicktest"

--- a/python34.rb
+++ b/python34.rb
@@ -144,7 +144,7 @@ class Python34 < Formula
 
     ENV.deparallelize # Installs must be serialized
     # Tell Python not to install into /Applications (default for framework builds)
-    system "make", "install", "PYTHONAPPSDIR=#{prefix}"
+    system "make", "altinstall", "PYTHONAPPSDIR=#{prefix}"
     # Demos and Tools
     system "make", "frameworkinstallextras", "PYTHONAPPSDIR=#{share}/python3"
     system "make", "quicktest" if build.include? "quicktest"


### PR DESCRIPTION
If we installed python3.5 already and try to install homebrew-python/python33, homebrew cannot create symlink '/usr/local/bin/python3' to '/usr/local/Cellar/python33/{version}/bin/python3.3' because '/usr/local/bin/python3' (-> python3.5) symlink exists already.
Older version of python should be installed by 'make altinstall'. This command create symlink of specific version of python like  '/usr/local/bin/python3.3' only.  
Please see also http://stackoverflow.com/questions/16018463/difference-in-details-between-make-install-and-make-altinstall
